### PR TITLE
Added support for custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Make sure that you've installed the [fugitive.vim](https://github.com/tpope/vim-
 ## FAQ
 
 1. Which domains are supported?
-> For now, only repositories under `dev.azure.com` will work.
+> You can change the domain by setting `g:fugitive_azure_devops_baseurl`. Defaults is `dev.azure.com`
 2. Is Omni completion supported?
 > Not currently. This could be done via the [Azure DevOps REST API](https://docs.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-5.0).
 

--- a/autoload/azuredevops.vim
+++ b/autoload/azuredevops.vim
@@ -2,6 +2,7 @@ if exists('g:autoloaded_fugitive_azure_devops')
   finish
 endif
 let g:autoloaded_fugitive_azure_devops = 1
+let s:fugitive_azure_devops_baseurl = get(g:, 'fugitive_azure_devops_baseurl', 'dev\.azure\.com')
 
 function! azuredevops#fugitive_handler(opts, ...) abort
   let path   = substitute(get(a:opts, 'path', ''), '^/', '', '')
@@ -36,8 +37,6 @@ function! azuredevops#fugitive_handler(opts, ...) abort
 endfunction
 
 function! azuredevops#homepage_for_remote(remote) abort
-  let domain_pattern = 'dev\.azure\.com'
-
   if !exists('g:fugitive_azure_devops_ssh_user')
     let g:fugitive_azure_devops_ssh_user = 'git'
   endif
@@ -57,7 +56,7 @@ function! azuredevops#homepage_for_remote(remote) abort
     \                          g:fugitive_azure_devops_ssh_user . '@\|' .
     \                          g:fugitive_azure_devops_ssh_user . '@ssh\.\|' .
     \                          'ssh://' . g:fugitive_azure_devops_ssh_user . '@\|\)' .
-    \                          '\%(.\{-\}@\)\=\zs\(' . domain_pattern . '\)[/:].\{-\}\ze\%(\.git\)\=$')
+    \                          '\%(.\{-\}@\)\=\zs\(' . s:fugitive_azure_devops_baseurl . '\)[/:].\{-\}\ze\%(\.git\)\=$')
 
   if url == ''
     return ''


### PR DESCRIPTION
I wanted to use this plugin with Azure DevOps however I use the self hosted version. I was able to add support for custom domain which will allow anyone who doesn't use the cloud version of Azure DevOps to use this plugin with some additional configuration. 